### PR TITLE
Add connect_mode argument

### DIFF
--- a/esphomeflasher/__main__.py
+++ b/esphomeflasher/__main__.py
@@ -54,6 +54,11 @@ def parse_args(argv):
         default=ESP32_DEFAULT_OTA_DATA,
     )
     parser.add_argument(
+        '--connect_mode',
+        help="Connect Mode (similar to esptool 'before' argument)",
+        default="default_reset"
+    )
+    parser.add_argument(
         "--no-erase", help="Do not erase flash before flashing", action="store_true"
     )
     parser.add_argument("--show-logs", help="Only show logs", action="store_true")

--- a/esphomeflasher/common.py
+++ b/esphomeflasher/common.py
@@ -212,13 +212,13 @@ def configure_write_flash_args(
     return MockEsptoolArgs(flash_size, addr_filename, flash_mode, flash_freq)
 
 
-def detect_chip(port, force_esp8266=False, force_esp32=False):
+def detect_chip(port, force_esp8266=False, force_esp32=False, connect_mode='default_reset'):
     if force_esp8266 or force_esp32:
         klass = esptool.ESP32ROM if force_esp32 else esptool.ESP8266ROM
         chip = klass(port)
     else:
         try:
-            chip = esptool.ESPLoader.detect_chip(port)
+            chip = esptool.ESPLoader.detect_chip(port, connect_mode=connect_mode)
         except esptool.FatalError as err:
             if "Wrong boot mode detected" in str(err):
                 msg = "ESP is not in flash boot mode. If your board has a flashing pin, try again while keeping it pressed."
@@ -227,7 +227,7 @@ def detect_chip(port, force_esp8266=False, force_esp32=False):
             raise EsphomeflasherError(msg) from err
 
     try:
-        chip.connect()
+        chip.connect(mode=connect_mode)
     except esptool.FatalError as err:
         raise EsphomeflasherError(f"Error connecting to ESP: {err}") from err
 


### PR DESCRIPTION
Some funky ESP boards like the ESP32 D1 Mini have RTS/CTS inverted:
https://makersportal.com/shop/esp32-d1-mini-bluetoothwifi-board

The default_reset option will therefor always skip the bootloader. esptool has an option to accommodate this, this pull requests allows you to pass that argument over to esptool:
```
esphomeflasher --esp32 --connect_mode no_reset opentherm.bin
```